### PR TITLE
Expand on instance example

### DIFF
--- a/pages.tex
+++ b/pages.tex
@@ -27,7 +27,7 @@ Let's begin by counting the number of paragraphs in a page:
   </head>
   <body>
     <h1>Title</h1>
-    <div class="fill"></div>
+    <div id="fill"></div>
     <h2 id="one">First <em>emphasized</em></h2>
     <p>stuff</p>
     <h2 id="two">Second <code>with code</code></h2>

--- a/pages.tex
+++ b/pages.tex
@@ -289,6 +289,9 @@ console.log(`distance between ${a} and ${b} is ${Vec2D.dist(a, b)}`)
 magnitude of (0,1) is 1
 distance between (0,1) and (1,0) is 1.4142135623730951
 \end{minted}
+
+We can call static methods directly on the class \texttt{Vec2D.dist},
+while \texttt{Vec2D.magnitude} is \texttt{undefined}.
 \end{aside}
 
 We then have three lines that do most of the function's work.


### PR DESCRIPTION
I read the new `Vec2D` example again within the context of the rest of the chapter and have a small suggestion:

This might need some verbiage clean up but despite the `console.log` of `a.magnitude` and `Vec2D.dist` I didn't quite make the connection that you CANNOT `Vec2D.magnitude`. I think adding the little bit about`Vec2D.magnitude = undefined` explicitly shows why/when static and instance methods are different. 