### PR TITLE
using event handler and object in the example

### DIFF
--- a/interactive.tex
+++ b/interactive.tex
@@ -34,10 +34,10 @@ in \chapref{s:dynamic}.)
 \end{minted}
 
 As its name suggests,
-a button's \texttt{onClick} handler is called whenever the button is clicked.
+\texttt{onClick} is the event handler called when a button is clicked.
 Here,
 we are telling React to call \texttt{sayHello},
-which adds one to the variable \texttt{counter}
+which adds one to the event object \texttt{counter}
 and then prints its value along with a greeting message.
 
 Global variables and functions are a poor way to structure code.


### PR DESCRIPTION
We define the `event handler` and `event object` in the paragraph before the example, but I think it helps to reinforce what these are by using those same words within the context of the example. 