### PR TITLE
remove redundant index entry

### DIFF
--- a/dynamic.tex
+++ b/dynamic.tex
@@ -493,7 +493,7 @@ for example,
 \texttt{dist/app.ef6b320b.js} is 19930 lines long.
 
 A more modern option than loading in the bottom is
-to add the \texttt{async} attribute\index{async attribute!\texttt{async} attribute}\index{running JavaScript!\texttt{async} attribute}
+to add the \texttt{async} attribute\index{\texttt{async} attribute}\index{running JavaScript!\texttt{async} attribute}
 to the script in the head of the page,
 which tells the browser not to do anything with the JavaScript until the page has finished building:
 


### PR DESCRIPTION
In the index, "`async` attribute" is a child of "async attribute", with no siblings. This seems unnecessary, unless there are other references to this attribute that we want to add?