### PR TITLE
Justify text in definition of hostname.

### DIFF
--- a/glossary.tex
+++ b/glossary.tex
@@ -298,9 +298,9 @@ homogeneous if it contains only numbers or only character strings, but not a
 mix of the two.
 
 \gitem{g:hostname}{hostname}
-The part of a URL that specifies the computer to talk to. In
-\texttt{http://example.com/something/}, the hostname is \texttt{example.com}; in
-\texttt{http://localhost:1234/}, it is \texttt{localhost}.
+The part of a URL that specifies the computer to talk to. In the URL
+\texttt{http://example.com/something/}, the hostname is \texttt{example.com};
+in the URL \texttt{http://localhost:1234/}, it is \texttt{localhost}.
 
 \gitem{g:http}{HyperText Transfer Protocol (HTTP)}
 The HyperText Transfer Protocol used to exchange information between browsers


### PR DESCRIPTION
Closes #186.