### PR TITLE
fixing mistake in exercise section of basics

### DIFF
--- a/basics.tex
+++ b/basics.tex
@@ -726,7 +726,7 @@ species is undefined
 \item
   How does \gref{g:destructuring}{destructuring assignment} work in general?
 \item
-  How can we use this technique to rewrite the \texttt{require} statement in \texttt{src/basics/import.js}
+  How can we use this technique to rewrite the \texttt{require} statement in \texttt{src/basics/application.js}
   so that \texttt{clip} can be called directly as \texttt{clip(...)} rather than as \texttt{utilities.clip(...)}?
 \end{enumerate}
 


### PR DESCRIPTION
I think in the 'Destructuring Assignment' subsection of the basics exercise section should link to application.js, not import.js
import.js doesn't have an import statement