### PR TITLE
thing.method(thing) -> thing.method() for OOP example

### DIFF
--- a/oop.tex
+++ b/oop.tex
@@ -234,8 +234,8 @@ const everything = [
   new Rectangle(1.5, 0.5)
 ]
 for (let thing of everything) {
-  const a = thing.area(thing)
-  const p = thing.perimeter(thing)
+  const a = thing.area()
+  const p = thing.perimeter()
   console.log(`${thing.name}: area ${a} perimeter ${p}`)
 }
 \end{minted}

--- a/src/oop/es6-objects.js
+++ b/src/oop/es6-objects.js
@@ -35,7 +35,7 @@ const everything = [
   new Rectangle(1.5, 0.5)
 ]
 for (let thing of everything) {
-  const a = thing.area(thing)
-  const p = thing.perimeter(thing)
+  const a = thing.area()
+  const p = thing.perimeter()
   console.log(`${thing.name}: area ${a} perimeter ${p}`)
 }


### PR DESCRIPTION
Changes `thing.area(thing)` to `thing.area()` and `thing.perimeter(thing)` to `thing.perimeter()` in using-oop examples. 